### PR TITLE
fix assert fail when reuse mnemonic global buffer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ifneq ($(dep_files),)
 endif
 
 %.o: %.c
-	$(CC) $(CFLAGS) -Wp,-MD,$(dep_file) -c -o $@ $<
+	$(CC) $(CFLAGS) -Wp,-MD,$(<:.c=.d) -c -o $@ $<
 
 wordlists.c: wordlist_slip0039.txt wordlist_bip0039_english.txt \
 	wordlist_diceware_german.txt wordlists2c.sh

--- a/slip0039.c
+++ b/slip0039.c
@@ -227,6 +227,7 @@ void slip0039_print_mnemonics(slip0039_t *s) {
 
 
 			base1024_append_checksum(&b);
+			wipememory(mnemonic, sizeof(mnemonic));
 			base1024_to_string(&b, mnemonic);
 			printf("%s\n", mnemonic);
 


### PR DESCRIPTION
The global buffer `mnemonic` is reused for every line, but each time encode base1024 to words, the program will assert every buffer element is `\0`.