### PR TITLE
Improve memory wipe and lock

### DIFF
--- a/slip0039.c
+++ b/slip0039.c
@@ -48,6 +48,11 @@ pbkdf2_t prng;                // PRNG for shares and part of digests
 const char *seed = NULL;
 size_t seed_len = 0;
 
+#define STACK_CLEAR_SIZE 256 * 1024
+#if defined(__APPLE__) && defined(__MACH__)
+const void *stackbase = NULL;
+#endif
+
 // call exit on receiving fatal signals
 void sig_handler(int signum) {
 	FATAL("%s", strsignal(signum));
@@ -127,6 +132,38 @@ void slip0039_debug(slip0039_t *s) {
 	DEBUG("---END-----internal slip0039 data----");
 }
 
+#if defined(__APPLE__) && defined(__MACH__)
+static void _mlock(const void *const p, const char* const var, const size_t len) {
+	if (p && len && mlock(p, len) < 0) {
+		FATAL("failed locking %s(%u) in RAM: %s", var, (unsigned int)len, strerror(errno));
+	}
+}
+static void _munlock(const void *const p, const char* const var, const size_t len) {
+	if (p && len && munlock(p, len) < 0) {
+		WARNING("failed unlocking %s(%u) in RAM: %s", var, (unsigned int)len, strerror(errno));
+	}
+}
+#define mlock_obj(p) do { \
+	void *_p = &p; \
+	_mlock(_p, #p, sizeof(p)); \
+} while (0)
+#define munlock_obj(p) do { \
+	void *_p = &p; \
+	_munlock(_p, #p, sizeof(p)); \
+} while (0)
+#define mlock_ptr(p, len) do { \
+	void *_p = &p; \
+	_mlock(_p, "&" #p, sizeof(p)); \
+	_mlock((p), #p, (len)); \
+} while (0)
+#define munlock_ptr(p, len) do { \
+	void *_p = &p; \
+	_mlock(p, #p, (len)); \
+	wipememory(_p, sizeof(p)); \
+	_mlock(_p, "&" #p, sizeof(p)); \
+} while (0)
+#endif
+
 // function that gets called atexit(), so that
 // sensitive contents are removed from memory
 void wipe() {
@@ -137,6 +174,24 @@ void wipe() {
 	wipememory(dl, sizeof(dl));
 	wipememory(seed, seed_len);
 	pbkdf2_finished(&prng);
+
+#if defined(__APPLE__) && defined(__MACH__)
+	munlock_ptr(stackbase, STACK_CLEAR_SIZE);
+	munlock_obj(s);
+	munlock_obj(mnemonic);
+	munlock_obj(b);
+	munlock_obj(dl);
+	munlock_ptr(seed, seed_len);
+	wipememory(&seed_len, sizeof(seed_len));
+	munlock_obj(seed_len);
+	munlock_obj(prng);
+#else
+	wipememory(&seed, sizeof(seed));
+	wipememory(&seed_len, sizeof(seed_len));
+	if (munlockall() < 0)
+                WARNING("failed locking process in RAM: %s",
+                                strerror(errno));
+#endif
 }
 
 void slip0039_init(slip0039_t *s) {
@@ -520,8 +575,14 @@ void slip0039_encrypt(slip0039_t *s) {
 
 void boring_stuff() {
 #if defined(__APPLE__) && defined(__MACH__)
-#	warning MACOS does not implement mlockall() api, your secret would be write to swap disk!
-	WARNING("MACOS does not implement mlockall() api, your secret would be write to swap disk!");
+	mlock_ptr(stackbase, STACK_CLEAR_SIZE);
+	mlock_obj(s);
+	mlock_obj(mnemonic);
+	mlock_obj(b);
+	mlock_obj(dl);
+	mlock_obj(seed);
+	mlock_obj(seed_len);
+	mlock_obj(prng);
 #else
         /* lock me into memory; don't leak info to swap */
         if (mlockall(MCL_CURRENT|MCL_FUTURE)<0)
@@ -567,6 +628,9 @@ void parse_options_split(slip0039_t *s, char *arg,
 		assert(!seed && seed_len == 0);
 		seed = arg;
 		seed_len = strlen(seed);
+#if defined(__APPLE__) && defined(__MACH__)
+		mlock_ptr(seed, seed_len);
+#endif
 		if (seed_len < 4) WARNING("specified value for SEED is very "
 				"short, consider using a longer value");
 		sha256(sha, seed, seed_len);
@@ -659,6 +723,11 @@ void parse_options(slip0039_t *s, int argc, char *argv[]) {
 }
 
 int main(int argc, char *argv[]) {
+#if defined(__APPLE__) && defined(__MACH__)
+	// save stackbase for locking stack memory
+	stackbase = (char*)&argc - STACK_CLEAR_SIZE;
+#endif
+
 	verbose_init(argv[0]);
 	boring_stuff();
 
@@ -698,4 +767,6 @@ int main(int argc, char *argv[]) {
 
 		slip0039_print_plaintext(&s);
 	}
+
+	 wipestackmemory(STACK_CLEAR_SIZE);
 }

--- a/utils.c
+++ b/utils.c
@@ -184,3 +184,10 @@ int sbufprintf_base16(sbuf_t *s, const uint8_t *buf, size_t len) {
 
 	return ret;
 }
+
+void wipestackmemory(const size_t len) {
+    // only support GCC or C99+ compiler
+    unsigned char fodder[len];
+    if (len > 0)
+		wipememory(fodder, len);
+}

--- a/utils.h
+++ b/utils.h
@@ -34,11 +34,14 @@
 #define wipememory2(_ptr,_set,_len) do { \
         volatile char *_vptr=(volatile char *)(_ptr); \
         size_t _vlen=(size_t)(_len); /*, ctr = 0;*/ \
+	if (!_vptr) break; \
         while(_vlen) { \
                 *_vptr=(_set); _vptr++; _vlen--; \
         } \
 } while(0)
 #define wipememory(_ptr,_len) wipememory2(_ptr,0,_len)
+
+void wipestackmemory(const size_t len);
 
 typedef struct sbuf_s {
 	char *buf;


### PR DESCRIPTION
1. wipe 256K stack memory when leaving main()
2. wipe seed address and seed len
3. manually lock confidential mem including stack of main() for MacOS
4. unlock after wiping memory

Pass test on macos & linux.